### PR TITLE
Fix input stream leak in schema inference

### DIFF
--- a/src/main/scala/com/scb/spark/sas/SasUtil.scala
+++ b/src/main/scala/com/scb/spark/sas/SasUtil.scala
@@ -5,7 +5,6 @@ import org.apache.spark.sql.types._
 import org.apache.hadoop.fs.{FileSystem, Path}
 import org.apache.hadoop.conf.Configuration
 
-import java.io.FileInputStream
 import scala.collection.JavaConverters._
 
 object SasUtil {
@@ -13,18 +12,22 @@ object SasUtil {
     val hadoopPath = new Path(path)
     val fs = FileSystem.get(hadoopPath.toUri, new Configuration())
     val inputStream = fs.open(hadoopPath)
-    val reader = new SasFileReaderImpl(inputStream)
+    try {
+      val reader = new SasFileReaderImpl(inputStream)
 
-    val fields = reader.getColumns.asScala.toSeq.map { sasCol =>
-      val colType = sasCol.getType match {
-        case t if t == classOf[String]  => StringType
-        case t if t == classOf[Double]  => DoubleType
-        case t if t == classOf[Integer] => IntegerType
-        case t if t == classOf[java.util.Date] => TimestampType
-        case _                          => StringType
+      val fields = reader.getColumns.asScala.toSeq.map { sasCol =>
+        val colType = sasCol.getType match {
+          case t if t == classOf[String]  => StringType
+          case t if t == classOf[Double]  => DoubleType
+          case t if t == classOf[Integer] => IntegerType
+          case t if t == classOf[java.util.Date] => TimestampType
+          case _                          => StringType
+        }
+        StructField(sasCol.getName, colType, nullable = true)
       }
-      StructField(sasCol.getName, colType, nullable = true)
+      StructType(fields)
+    } finally {
+      inputStream.close()
     }
-    StructType(fields)
   }
 }


### PR DESCRIPTION
## Summary
- close SAS file input streams properly when inferring schema
- clean up unused import

## Testing
- `sbt test` *(fails: `sbt: command not found`)*

------
https://chatgpt.com/codex/tasks/task_e_684458f42eb48333824e588590960729